### PR TITLE
Fix quantized preprocessing buffer type

### DIFF
--- a/Nanodet_OD_pest.ino
+++ b/Nanodet_OD_pest.ino
@@ -157,7 +157,9 @@ bool preprocessFrame(camera_fb_t* fb, int8_t* input_buffer) {
   logMessage(LOG_INFO, "🎨 Using test pattern " + String(current_test_pattern));
   
   // Create temporary HWC buffer first
-  uint8_t* temp_hwc_buffer = (uint8_t*)malloc(MODEL_WIDTH * MODEL_HEIGHT * MODEL_CHANNELS);
+  // Use signed buffer to correctly store quantized INT8 values
+  size_t hwc_bytes = MODEL_WIDTH * MODEL_HEIGHT * MODEL_CHANNELS;
+  int8_t* temp_hwc_buffer = (int8_t*)malloc(hwc_bytes);
   if (!temp_hwc_buffer) {
     logMessage(LOG_ERROR, "Failed to allocate temporary HWC buffer");
     return false;


### PR DESCRIPTION
## Summary
- Use signed buffer in preprocessing to preserve INT8 values
- Allocate buffer with explicit size to avoid sign issues

## Testing
- `g++ -std=c++17 -Wall -Werror -x c++ -c Nanodet_OD_pest.ino` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6893132a56088327bf29443d78f908f7